### PR TITLE
implement value collection for controlled vocabularies

### DIFF
--- a/src/main/java/life/qbic/expdesign/SamplePreparator.java
+++ b/src/main/java/life/qbic/expdesign/SamplePreparator.java
@@ -365,8 +365,13 @@ public class SamplePreparator {
     return experimentalDesignXML;
   }
 
-  public Map<String, List<String>> getParsedCategoriesToValues(ArrayList<String> cats) {
-    return reader.getParsedCategoriesToValues(cats);
+  /**
+   * Returns a map containing lists of unique values from an experimental design format based on property names
+   * @param names a list of property names found in the format for which data should be returned
+   * @return a mapping between property names and a list of unique values read by the respective parser of the format
+   */
+  public Map<String, List<String>> getParsedValuesForCategories(ArrayList<String> names) {
+    return reader.getParsedValuesForColumns(names);
   }
 
 }

--- a/src/main/java/life/qbic/expdesign/io/EasyDesignReader.java
+++ b/src/main/java/life/qbic/expdesign/io/EasyDesignReader.java
@@ -709,13 +709,13 @@ public class EasyDesignReader implements IExperimentalDesignReader {
   }
 
   @Override
-  public Map<String, List<String>> getParsedCategoriesToValues(List<String> header) {
+  public Map<String, List<String>> getParsedValuesForColumns(List<String> colNames) {
     Map<String, List<String>> res = new HashMap<>();
-    for (String cat : header) {
-      if (parsedCategoriesToValues.containsKey(cat)) {
-        res.put(cat, new ArrayList<>(parsedCategoriesToValues.get(cat)));
+    for (String columnName : colNames) {
+      if (parsedCategoriesToValues.containsKey(columnName)) {
+        res.put(columnName, new ArrayList<>(parsedCategoriesToValues.get(columnName)));
       } else {
-        logger.warn(cat + " not found");
+        logger.warn(columnName + " not found");
       }
     }
     return res;

--- a/src/main/java/life/qbic/expdesign/io/IExperimentalDesignReader.java
+++ b/src/main/java/life/qbic/expdesign/io/IExperimentalDesignReader.java
@@ -2,8 +2,6 @@ package life.qbic.expdesign.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +33,13 @@ public interface IExperimentalDesignReader {
   int countEntities(File file) throws IOException;
 
   List<TechnologyType> getTechnologyTypes();
-  
-  public Map<String, List<String>> getParsedCategoriesToValues(List<String> header);
+
+  /**
+   * Returns a map containing lists of unique values found in the respective columns of a file based on the column names
+   * in the header
+   * @param colNames a list of column names for which data should be returned
+   * @return a mapping between column names and a list of unique values read by the parser
+   */
+  public Map<String, List<String>> getParsedValuesForColumns(List<String> colNames);
 
 }

--- a/src/main/java/life/qbic/expdesign/io/MHCLigandDesignReader.java
+++ b/src/main/java/life/qbic/expdesign/io/MHCLigandDesignReader.java
@@ -35,6 +35,7 @@ public class MHCLigandDesignReader implements IExperimentalDesignReader {
   private List<String> mandatoryFilled;
   private List<String> optionalCols;
   private Map<SampleType, Map<String, String>> headersToTypeCodePerSampletype;
+  private Map<String, Set<String>> parsedCategoriesToValues;
   private String msSampleXML =
       "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?> <qproperties> <qfactors> <qcategorical label=\"technical_replicate\" value=\"%repl\"/> <qcategorical label=\"workflow_type\" value=\"%wftype\"/> </qfactors> </qproperties>";
 
@@ -138,7 +139,32 @@ public class MHCLigandDesignReader implements IExperimentalDesignReader {
     headersToTypeCodePerSampletype.put(SampleType.Q_MHC_LIGAND_EXTRACT, ligandsMetadata);
     // headersToTypeCodePerSampletype.put("Q_MS_RUN", msRunMetadata);
   }
+  private void fillParsedCategoriesToValuesForRow(Map<String, Integer> headerMapping,
+      String[] row) {
+    // logger.info("Collecting possible CV entries for row.");
+    addValueForCategory(headerMapping, row, "Organism");
+    addValueForCategory(headerMapping, row, "Tissue");
+    addValueForCategory(headerMapping, row, "Dignity");
+    addValueForCategory(headerMapping, row, "Tumor Type");
+    addValueForCategory(headerMapping, row, "TNM");
+    addValueForCategory(headerMapping, row, "Antibody");
+    addValueForCategory(headerMapping, row, "MHC Class");
+  }
 
+  private void addValueForCategory(Map<String, Integer> headerMapping, String[] row, String cat) {
+    if (headerMapping.containsKey(cat)) {
+      String val = row[headerMapping.get(cat)];
+      if (val != null && !val.isEmpty()) {
+          if (parsedCategoriesToValues.containsKey(cat)) {
+            parsedCategoriesToValues.get(cat).add(val);
+          } else {
+            Set<String> set = new HashSet<String>();
+            set.add(val);
+            parsedCategoriesToValues.put(cat, set);
+        }
+      }
+    }
+  }
   public Map<String, List<Map<String, Object>>> getExperimentInfos() {
     return experimentInfos;
   }
@@ -163,6 +189,7 @@ public class MHCLigandDesignReader implements IExperimentalDesignReader {
    */
   public List<ISampleBean> readSamples(File file, boolean parseGraph) throws IOException {
     tsvByRows = new ArrayList<String>();
+    parsedCategoriesToValues = new HashMap<>();
 
     BufferedReader reader = new BufferedReader(new FileReader(file));
     ArrayList<String[]> data = new ArrayList<String[]>();
@@ -261,6 +288,7 @@ public class MHCLigandDesignReader implements IExperimentalDesignReader {
     int rowID = 0;
     int sampleID = 0;
     for (String[] row : data) {
+      fillParsedCategoriesToValuesForRow(headerMapping, row);
       rowID++;
       boolean special = false;
       if (!special) {
@@ -723,8 +751,15 @@ public class MHCLigandDesignReader implements IExperimentalDesignReader {
 
   @Override
   public Map<String, List<String>> getParsedCategoriesToValues(List<String> header) {
-    logger.warn("Method getParsedCategoriesToValues not implemented.");
-    return new HashMap<>();
+    Map<String, List<String>> res = new HashMap<>();
+    for (String cat : header) {
+      if (parsedCategoriesToValues.containsKey(cat)) {
+        res.put(cat, new ArrayList<>(parsedCategoriesToValues.get(cat)));
+      } else {
+        logger.warn(cat + " not found");
+      }
+    }
+    return res;
   }
 
 }

--- a/src/main/java/life/qbic/expdesign/io/MHCLigandDesignReader.java
+++ b/src/main/java/life/qbic/expdesign/io/MHCLigandDesignReader.java
@@ -750,13 +750,13 @@ public class MHCLigandDesignReader implements IExperimentalDesignReader {
   }
 
   @Override
-  public Map<String, List<String>> getParsedCategoriesToValues(List<String> header) {
+  public Map<String, List<String>> getParsedValuesForColumns(List<String> colNames) {
     Map<String, List<String>> res = new HashMap<>();
-    for (String cat : header) {
-      if (parsedCategoriesToValues.containsKey(cat)) {
-        res.put(cat, new ArrayList<>(parsedCategoriesToValues.get(cat)));
+    for (String columnName : colNames) {
+      if (parsedCategoriesToValues.containsKey(columnName)) {
+        res.put(columnName, new ArrayList<>(parsedCategoriesToValues.get(columnName)));
       } else {
-        logger.warn(cat + " not found");
+        logger.warn(columnName + " not found");
       }
     }
     return res;

--- a/src/main/java/life/qbic/expdesign/io/MSDesignReader.java
+++ b/src/main/java/life/qbic/expdesign/io/MSDesignReader.java
@@ -952,13 +952,13 @@ public class MSDesignReader implements IExperimentalDesignReader {
   }
 
   @Override
-  public Map<String, List<String>> getParsedCategoriesToValues(List<String> header) {
+  public Map<String, List<String>> getParsedValuesForColumns(List<String> colNames) {
     Map<String, List<String>> res = new HashMap<>();
-    for (String cat : header) {
-      if (parsedCategoriesToValues.containsKey(cat)) {
-        res.put(cat, new ArrayList<>(parsedCategoriesToValues.get(cat)));
+    for (String columnName : colNames) {
+      if (parsedCategoriesToValues.containsKey(columnName)) {
+        res.put(columnName, new ArrayList<>(parsedCategoriesToValues.get(columnName)));
       } else {
-        logger.warn(cat + " not found");
+        logger.warn(columnName + " not found");
       }
     }
     return res;

--- a/src/main/java/life/qbic/expdesign/io/MetaboDesignReader.java
+++ b/src/main/java/life/qbic/expdesign/io/MetaboDesignReader.java
@@ -672,13 +672,13 @@ public class MetaboDesignReader implements IExperimentalDesignReader {
   }
 
   @Override
-  public Map<String, List<String>> getParsedCategoriesToValues(List<String> header) {
+  public Map<String, List<String>> getParsedValuesForColumns(List<String> colNames) {
     Map<String, List<String>> res = new HashMap<>();
-    for (String cat : header) {
-      if (parsedCategoriesToValues.containsKey(cat)) {
-        res.put(cat, new ArrayList<>(parsedCategoriesToValues.get(cat)));
+    for (String columnName : colNames) {
+      if (parsedCategoriesToValues.containsKey(columnName)) {
+        res.put(columnName, new ArrayList<>(parsedCategoriesToValues.get(columnName)));
       } else {
-        logger.warn(cat + " not found");
+        logger.warn(columnName + " not found");
       }
     }
     return res;

--- a/src/main/java/life/qbic/expdesign/io/QBiCDesignReader.java
+++ b/src/main/java/life/qbic/expdesign/io/QBiCDesignReader.java
@@ -542,8 +542,8 @@ public class QBiCDesignReader implements IExperimentalDesignReader {
   }
 
   @Override
-  public Map<String, List<String>> getParsedCategoriesToValues(List<String> header) {
-    logger.warn("Method getParsedCategoriesToValues not implemented.");
+  public Map<String, List<String>> getParsedValuesForColumns(List<String> colNames) {
+    logger.warn("Method getParsedValuesForColumns not implemented.");
     return new HashMap<>();
   }
 

--- a/src/main/java/life/qbic/isatab/ISAReader.java
+++ b/src/main/java/life/qbic/isatab/ISAReader.java
@@ -756,7 +756,8 @@ public class ISAReader implements IExperimentalDesignReader {
   }
 
   @Override
-  public Map<String, List<String>> getParsedCategoriesToValues(List<String> header) {
+  public Map<String, List<String>> getParsedValuesForColumns(List<String> colNames) {
+    log.warn("Method getParsedValuesForColumns not implemented.");
     return null;
   }
 }

--- a/src/test/java/life/qbic/expdesign/io/MSDesignReaderTest.java
+++ b/src/test/java/life/qbic/expdesign/io/MSDesignReaderTest.java
@@ -291,7 +291,7 @@ public class MSDesignReaderTest {
    p.processTSV(tsv, new MSDesignReader(), false);
    System.out.println("vocabs");
    System.out
-   .println(p.getParsedCategoriesToValues(new ArrayList<String>(Arrays.asList("LC Column",
+   .println(p.getParsedValuesForCategories(new ArrayList<>(Arrays.asList("LC Column",
    "MS Device", "Fractionation Type", "Enrichment Type", "Labeling Type", "LCMS Method",
    "Digestion Method", "Digestion Enzyme", "Sample Preparation", "Species", "Tissue"))));
   

--- a/src/test/java/life/qbic/expdesign/io/MetaboDesignReaderTest.java
+++ b/src/test/java/life/qbic/expdesign/io/MetaboDesignReaderTest.java
@@ -243,7 +243,7 @@ public class MetaboDesignReaderTest {
     MetaboDesignReader r = new MetaboDesignReader();
     p.processTSV(fullExample1, r, false);
     System.out.println("vocabs");
-    System.out.println(p.getParsedCategoriesToValues(new ArrayList<String>(
+    System.out.println(p.getParsedValuesForCategories(new ArrayList<>(
         Arrays.asList("Medium", "Harvesting conditions", "LCMS method name", "LC device",
             "LC detection method", "MS device", "MS ion mode", "Species", "Biospecimen"))));
 


### PR DESCRIPTION
Collect unique values for certain columns controlled by vocabularies in the MHC Ligand import format. This enables software using this library to easily validate these values and allow users to fix errors, as it is done with other import formats.